### PR TITLE
도커 파일 삭제

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,0 @@
-FROM openjdk:17-jdk-slim
-ADD /build/libs/*.jar app.jar
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]


### PR DESCRIPTION
삭제 이유 : Docker의 기본은 리눅스 OS에 대한 이해와 가상화 기술에 대한 이해가 선행되어야 함. 리눅스 OS에 대한 개념이 없는 상호아에서 사용하는 것은  실속없는 사용이라 판단.